### PR TITLE
Update to bdk-swift 0.3.0

### DIFF
--- a/BdkSwiftSample.xcodeproj/project.pbxproj
+++ b/BdkSwiftSample.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		6EA8DBC8275BD796001B935E /* RecoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBC2275BD796001B935E /* RecoverView.swift */; };
 		6EA8DBC9275BD796001B935E /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBC3275BD796001B935E /* ReceiveView.swift */; };
 		6EA8DBCB275BD87E001B935E /* WalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBCA275BD87E001B935E /* WalletViewModel.swift */; };
-		6EA8DBCE275BD9EE001B935E /* BitcoinDevKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6EA8DBCD275BD9EE001B935E /* BitcoinDevKit */; };
+		AA73CD0A282F08A9006CAD0D /* BitcoinDevKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA73CD09282F08A9006CAD0D /* BitcoinDevKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,8 +62,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA73CD0A282F08A9006CAD0D /* BitcoinDevKit in Frameworks */,
 				6E3A739827643BCE00965365 /* CodeScanner in Frameworks */,
-				6EA8DBCE275BD9EE001B935E /* BitcoinDevKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,8 +155,8 @@
 			);
 			name = BdkSwiftSample;
 			packageProductDependencies = (
-				6EA8DBCD275BD9EE001B935E /* BitcoinDevKit */,
 				6E3A739727643BCE00965365 /* CodeScanner */,
+				AA73CD09282F08A9006CAD0D /* BitcoinDevKit */,
 			);
 			productName = BdkSwiftSample;
 			productReference = 6EA8DB97275BD298001B935E /* BdkSwiftSample.app */;
@@ -189,6 +189,7 @@
 			packageReferences = (
 				6EA8DBCC275BD9EE001B935E /* XCRemoteSwiftPackageReference "bdk-swift" */,
 				6E3A739627643BCE00965365 /* XCRemoteSwiftPackageReference "CodeScanner" */,
+				AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */,
 			);
 			productRefGroup = 6EA8DB98275BD298001B935E /* Products */;
 			projectDirPath = "";
@@ -457,6 +458,14 @@
 				minimumVersion = 0.1.4;
 			};
 		};
+		AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/bitcoindevkit/bdk-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -465,9 +474,9 @@
 			package = 6E3A739627643BCE00965365 /* XCRemoteSwiftPackageReference "CodeScanner" */;
 			productName = CodeScanner;
 		};
-		6EA8DBCD275BD9EE001B935E /* BitcoinDevKit */ = {
+		AA73CD09282F08A9006CAD0D /* BitcoinDevKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6EA8DBCC275BD9EE001B935E /* XCRemoteSwiftPackageReference "bdk-swift" */;
+			package = AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */;
 			productName = BitcoinDevKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/BdkSwiftSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BdkSwiftSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "bdk-swift",
-        "repositoryURL": "https://github.com/bitcoindevkit/bdk-swift",
-        "state": {
-          "branch": null,
-          "revision": "f2b857a609001b29f6663c9a2646a0d814d0e7e9",
-          "version": "0.1.4"
-        }
-      },
-      {
-        "package": "CodeScanner",
-        "repositoryURL": "https://github.com/twostraws/CodeScanner",
-        "state": {
-          "branch": null,
-          "revision": "8a9ce909a4ea502d4a2ccf327ae8c16b7e48e740",
-          "version": "1.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "bdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitcoindevkit/bdk-swift",
+      "state" : {
+        "revision" : "5622b070479578490c43cb2f31200215a2c1d1b6",
+        "version" : "0.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "codescanner",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/twostraws/CodeScanner",
+      "state" : {
+        "revision" : "8a9ce909a4ea502d4a2ccf327ae8c16b7e48e740",
+        "version" : "1.1.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/BdkSwiftSample/Components/SendReceiveButtons.swift
+++ b/BdkSwiftSample/Components/SendReceiveButtons.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import BitcoinDevKit
 
 struct SendReceiveButtons: View {
-    var wallet: OnlineWallet
+    var wallet: Wallet
+    var blockchain: Blockchain
     
     func getWidth(w: CGFloat) -> CGFloat {
         return (w - 10.0) / 2.0
@@ -26,10 +27,12 @@ struct SendReceiveButtons: View {
         // Invisible link to Send
         NavigationLink(destination: SendView(onSend: { recipient, amount in
             do {
-                let psbt = try PartiallySignedBitcoinTransaction(wallet: wallet, recipient: recipient, amount: amount, feeRate: nil)
+                let txBuilder = TxBuilder().addRecipient(address: recipient, amount: amount)
+                let psbt = try txBuilder.finish(wallet: wallet)
                 try wallet.sign(psbt: psbt)
-                let transaction = try wallet.broadcast(psbt: psbt)
-                print(transaction)
+                try blockchain.broadcast(psbt: psbt)
+                let txid = psbt.txid()
+                print(txid)
             } catch let error {
                 print(error)
             }

--- a/BdkSwiftSample/Components/SingleTxView.swift
+++ b/BdkSwiftSample/Components/SingleTxView.swift
@@ -35,7 +35,7 @@ struct SingleTxView: View {
                     }
                     HStack {
                         Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.fees ?? 0)).textStyle(BasicTextStyle(white: true))
+                        Text(String(details.fee ?? 0)).textStyle(BasicTextStyle(white: true))
                     }
                     HStack {
                         Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
@@ -60,7 +60,7 @@ struct SingleTxView: View {
                     }
                     HStack {
                         Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.fees ?? 0)).textStyle(BasicTextStyle(white: true))
+                        Text(String(details.fee ?? 0)).textStyle(BasicTextStyle(white: true))
                     }
                     HStack {
                         Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
@@ -81,6 +81,6 @@ struct SingleTxView: View {
 
 struct SingleTxView_Previews: PreviewProvider {
     static var previews: some View {
-        SingleTxView(transaction: Transaction.confirmed(details: TransactionDetails(fees: nil, received: 1000, sent: 10000, txid: "some-other-tx-id"), confirmation: Confirmation(height: 20087, timestamp: 1635863544)))
+        SingleTxView(transaction: Transaction.confirmed(details: TransactionDetails(fee: nil, received: 1000, sent: 10000, txid: "some-other-tx-id"), confirmation: BlockTime(height: 20087, timestamp: 1635863544)))
     }
 }

--- a/BdkSwiftSample/HomeView.swift
+++ b/BdkSwiftSample/HomeView.swift
@@ -35,9 +35,9 @@ struct HomeView: View {
                 BasicButton(action: { goToTxs = true}, text: "transaction history")
             }.padding(.bottom, 10)
             switch viewModel.state {
-                case .loaded(let wallet):
+                case .loaded(let wallet, let blockchain):
                     do {
-                        SendReceiveButtons(wallet: wallet)
+                        SendReceiveButtons(wallet: wallet, blockchain: blockchain)
                     }
                 default: do { }
             }

--- a/BdkSwiftSample/ReceiveView.swift
+++ b/BdkSwiftSample/ReceiveView.swift
@@ -23,7 +23,7 @@ struct ReceiveView: View {
     
     func getAddress() {
         switch viewModel.state {
-            case .loaded(let wallet):
+            case .loaded(let wallet, _):
                 do {
                     address = wallet.getNewAddress()
                 }

--- a/BdkSwiftSample/WalletView.swift
+++ b/BdkSwiftSample/WalletView.swift
@@ -9,12 +9,6 @@ import SwiftUI
 import Combine
 import BitcoinDevKit
 
-class Progress : BdkProgress {
-    func update(progress: Float, message: String?) {
-        print("progress", progress, message as Any)
-    }
-}
-
 struct WalletView: View {
     @EnvironmentObject var viewModel: WalletViewModel
     
@@ -31,7 +25,7 @@ struct WalletView: View {
                 VStack {Text("error")}
             case .loading:
                 VStack {Text("error")}
-            case .loaded(_):
+            case .loaded(_, _):
                 HomeView()
             }
         }.onAppear(perform: viewModel.load)


### PR DESCRIPTION
The new `bdk-swift` package is based on `bdk-ffi` 0.6.0 which is based on the latest and greatest `bdk` release 0.18.0.

Required changes for new bdk API:

1. A new `Blockchain` type was added that is created from a `BlockchainConfig`
2. `PartiallySignedBitcoinTransaction` are built using new `TxBuilder` (or `BumpFeeTxBuilder`)
3. `PartiallySignedBitcoinTransaction`s are broadcast using a `Blockchain`
4. `TransactionDetails.fees` renamed to `TransactionDetails.fee`
5. `Wallet.sync()` takes as a parameter a `Blockchain` 
6. `DatabaseConfig.memory` does not need a "junk" parameter anymore