### PR TITLE
Update bdk-swift 0.5.0, bdk-swift 0.9.0, bdk 0.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+BdkSwiftSample.xcodeproj/xcuserdata/

--- a/BdkSwiftSample.xcodeproj/project.pbxproj
+++ b/BdkSwiftSample.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		6EA8DBC8275BD796001B935E /* RecoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBC2275BD796001B935E /* RecoverView.swift */; };
 		6EA8DBC9275BD796001B935E /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBC3275BD796001B935E /* ReceiveView.swift */; };
 		6EA8DBCB275BD87E001B935E /* WalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8DBCA275BD87E001B935E /* WalletViewModel.swift */; };
-		AA1684AC28669BA500860C6E /* BitcoinDevKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA1684AB28669BA500860C6E /* BitcoinDevKit */; };
 		AA1684AE28669EF100860C6E /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = AA1684AD28669EF100860C6E /* CodeScanner */; };
+		AA40828928E7C59400A8B510 /* BitcoinDevKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA40828828E7C59400A8B510 /* BitcoinDevKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,8 +62,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA40828928E7C59400A8B510 /* BitcoinDevKit in Frameworks */,
 				AA1684AE28669EF100860C6E /* CodeScanner in Frameworks */,
-				AA1684AC28669BA500860C6E /* BitcoinDevKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,8 +163,8 @@
 			);
 			name = BdkSwiftSample;
 			packageProductDependencies = (
-				AA1684AB28669BA500860C6E /* BitcoinDevKit */,
 				AA1684AD28669EF100860C6E /* CodeScanner */,
+				AA40828828E7C59400A8B510 /* BitcoinDevKit */,
 			);
 			productName = BdkSwiftSample;
 			productReference = 6EA8DB97275BD298001B935E /* BdkSwiftSample.app */;
@@ -196,7 +196,7 @@
 			mainGroup = 6EA8DB8E275BD298001B935E;
 			packageReferences = (
 				6E3A739627643BCE00965365 /* XCRemoteSwiftPackageReference "CodeScanner" */,
-				AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */,
+				AA40828728E7C59400A8B510 /* XCRemoteSwiftPackageReference "bdk-swift" */,
 			);
 			productRefGroup = 6EA8DB98275BD298001B935E /* Products */;
 			projectDirPath = "";
@@ -457,26 +457,26 @@
 				version = 1.1.0;
 			};
 		};
-		AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */ = {
+		AA40828728E7C59400A8B510 /* XCRemoteSwiftPackageReference "bdk-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bitcoindevkit/bdk-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		AA1684AB28669BA500860C6E /* BitcoinDevKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AA73CD08282F08A9006CAD0D /* XCRemoteSwiftPackageReference "bdk-swift" */;
-			productName = BitcoinDevKit;
-		};
 		AA1684AD28669EF100860C6E /* CodeScanner */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6E3A739627643BCE00965365 /* XCRemoteSwiftPackageReference "CodeScanner" */;
 			productName = CodeScanner;
+		};
+		AA40828828E7C59400A8B510 /* BitcoinDevKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA40828728E7C59400A8B510 /* XCRemoteSwiftPackageReference "bdk-swift" */;
+			productName = BitcoinDevKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/BdkSwiftSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BdkSwiftSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bitcoindevkit/bdk-swift",
       "state" : {
-        "revision" : "320f95e4fa37ae4ce70d1fd6d57c1d431ab0a194",
-        "version" : "0.4.0"
+        "revision" : "5ccf19d4587ad9431d6e8285f2f11e13f7f4cc4d",
+        "version" : "0.5.1"
       }
     },
     {

--- a/BdkSwiftSample/Components/SingleTxView.swift
+++ b/BdkSwiftSample/Components/SingleTxView.swift
@@ -8,70 +8,59 @@
 import SwiftUI
 import BitcoinDevKit
 
-// TODO I don't know why "Transaction" is ambiguous
-extension BitcoinDevKit.Transaction {
-    public func getDetails() -> TransactionDetails {
-        switch self {
-        case .unconfirmed(let details): return details
-        case .confirmed(let details, _): return details
-        }
-    }
-}
-
 struct SingleTxView: View {
-    var transaction: BitcoinDevKit.Transaction
+    var transactionDetails: TransactionDetails
     
     var body: some View {
                 VStack(alignment: .leading, spacing: 5) {
-            switch transaction {
-            case .unconfirmed(let details):
-                    HStack {
-                        Text("Received:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.received)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Sent:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.sent)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.fee ?? 0)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(details.txid).textStyle(BasicTextStyle(white: true))
-                    }
-            case .confirmed(let details, let confirmation):
-                    HStack {
-                        Text("Confirmed:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text((Date(timeIntervalSince1970: TimeInterval(confirmation.timestamp)).getFormattedDate(format: "yyyy-MM-dd HH:mm:ss"))).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Block:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(confirmation.height)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Received:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.received)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Sent:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.sent)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(String(details.fee ?? 0)).textStyle(BasicTextStyle(white: true))
-                    }
-                    HStack {
-                        Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
-                        Text(details.txid).textStyle(BasicTextStyle(white: true))
-                    }
+                    if transactionDetails.confirmationTime == nil {
+                        HStack {
+                            Text("Received:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.received)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Sent:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.sent)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.fee ?? 0)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(transactionDetails.txid).textStyle(BasicTextStyle(white: true))
+                        }
+                    } else {
+                        HStack {
+                            Text("Confirmed:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text((Date(timeIntervalSince1970: TimeInterval(transactionDetails.confirmationTime!.timestamp)).getFormattedDate(format: "yyyy-MM-dd HH:mm:ss"))).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Block:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.confirmationTime!.height)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Received:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.received)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Sent:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.sent)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Fees:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(String(transactionDetails.fee ?? 0)).textStyle(BasicTextStyle(white: true))
+                        }
+                        HStack {
+                            Text("Txid:").textStyle(BasicTextStyle(white: true, bold: true))
+                            Text(transactionDetails.txid).textStyle(BasicTextStyle(white: true))
+                        }
                 }
         }.padding(10)
         .background(Color("Shadow")).cornerRadius(5)
         .contextMenu {
                 Button(action: {
-                    UIPasteboard.general.string = transaction.getDetails().txid}) {
+                    UIPasteboard.general.string = transactionDetails.txid}) {
                         Text("Copy TXID")
                     }
             }
@@ -81,6 +70,6 @@ struct SingleTxView: View {
 
 struct SingleTxView_Previews: PreviewProvider {
     static var previews: some View {
-        SingleTxView(transaction: Transaction.confirmed(details: TransactionDetails(fee: nil, received: 1000, sent: 10000, txid: "some-other-tx-id"), confirmation: BlockTime(height: 20087, timestamp: 1635863544)))
+        SingleTxView(transactionDetails: TransactionDetails(fee: 250, received: 1000, sent: 10000, txid: "some-other-tx-id", confirmationTime: BlockTime(height: 20087, timestamp: 1635863544)))
     }
 }

--- a/BdkSwiftSample/ReceiveView.swift
+++ b/BdkSwiftSample/ReceiveView.swift
@@ -59,7 +59,10 @@ struct ReceiveView: View {
                     .frame(width: 200, height: 200)
                 Spacer()
                 Text(splitAddress(address: address).0).textStyle(BasicTextStyle(white: true))
-                Text(splitAddress(address: address).1).textStyle(BasicTextStyle(white: true))
+                Text(splitAddress(address:  address).1).textStyle(BasicTextStyle(white: true))
+                    .onTapGesture(count: 1) {
+                        UIPasteboard.general.string = address
+                    }
                 Spacer()
             }.contextMenu {
                 Button(action: {

--- a/BdkSwiftSample/TxsView.swift
+++ b/BdkSwiftSample/TxsView.swift
@@ -8,15 +8,6 @@
 import SwiftUI
 import BitcoinDevKit
 
-//extension Transaction {
-//    public func getDetails() -> TransactionDetails {
-//        switch self {
-//        case Transaction.unconfirmed(let details): return details
-//        case Transaction.confirmed(let details, _): return details
-//        }
-//    }
-//}
-
 extension Date {
     func getFormattedDate(format: String) -> String {
         let dateformat = DateFormatter()
@@ -26,7 +17,7 @@ extension Date {
 }
 
 struct TxsView: View {
-//    var transactions: [BitcoinDevKit.Transaction]
+
     @EnvironmentObject var viewModel: WalletViewModel
     
     var body: some View {
@@ -36,17 +27,9 @@ struct TxsView: View {
                     Text("No transactions yet.").padding()
                 } else {
                     ForEach(viewModel.transactions, id: \.self) { transaction in
-                        SingleTxView(transaction: transaction)
+                        SingleTxView(transactionDetails: transaction)
                     }
                 }
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
-//                SingleTxView()
             }
         }
         .navigationTitle("Transactions")


### PR DESCRIPTION
Updated to latest and greatest `bdk-swift` 0.5.x which is based on `bdk-ffi` 0.9.0 which is based on `bdk` 0.22.

I also added:

* transaction list now sorts transactions from newest to oldest, with uncomfirmed on top.
* single tap on receive address copies address to cllipboard, useful for simulator testing.