### PR TITLE
Preview crash fix and background thread syncing

### DIFF
--- a/BdkSwiftSample/HomeView.swift
+++ b/BdkSwiftSample/HomeView.swift
@@ -50,5 +50,6 @@ struct HomeView: View {
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView()
+            .environmentObject(WalletViewModel())
     }
 }

--- a/BdkSwiftSample/ReceiveView.swift
+++ b/BdkSwiftSample/ReceiveView.swift
@@ -82,5 +82,6 @@ struct ReceiveView: View {
 struct ReceiveView_Previews: PreviewProvider {
     static var previews: some View {
         ReceiveView()
+            .environmentObject(WalletViewModel())
     }
 }

--- a/BdkSwiftSample/TxsView.swift
+++ b/BdkSwiftSample/TxsView.swift
@@ -40,6 +40,7 @@ struct TxsView: View {
 struct TxsView_Previews: PreviewProvider {
     static var previews: some View {
         TxsView()
+            .environmentObject(WalletViewModel())
     }
 }
 

--- a/BdkSwiftSample/WalletView.swift
+++ b/BdkSwiftSample/WalletView.swift
@@ -35,5 +35,6 @@ struct WalletView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         WalletView()
+            .environmentObject(WalletViewModel())
     }
 }


### PR DESCRIPTION
- Attaching environment object to prevent preview crashes (Only an issue in newer xcode I think)
- Moving load and sync functions into background threads, updating model fields from main thread so Ui doesn't hang when syncing